### PR TITLE
Contact.Distance() results were wrong due to missing ref keywords when writing to structs.

### DIFF
--- a/src/box2dx/Box2D.NetStandard/Collision/Simplex.cs
+++ b/src/box2dx/Box2D.NetStandard/Collision/Simplex.cs
@@ -71,7 +71,7 @@ namespace Box2D.NetStandard.Collision
 			SimplexVertex[] vertices = m_v;
 			for (var i = 0; i < m_count; ++i)
 			{
-				SimplexVertex v = vertices[i];
+				ref SimplexVertex v = ref vertices[i];
 				v.indexA = cache.indexA[i];
 				v.indexB = cache.indexB[i];
 				Vector2 wALocal = proxyA.GetVertex(v.indexA);
@@ -98,7 +98,7 @@ namespace Box2D.NetStandard.Collision
 			// If the cache is empty or invalid ...
 			if (m_count == 0)
 			{
-				SimplexVertex v = vertices[0];
+				ref SimplexVertex v = ref vertices[0];
 				v.indexA = 0;
 				v.indexB = 0;
 				Vector2 wALocal = proxyA.GetVertex(0);

--- a/src/box2dx/Box2D.NetStandard/Dynamics/Contacts/Contact.cs
+++ b/src/box2dx/Box2D.NetStandard/Dynamics/Contacts/Contact.cs
@@ -499,7 +499,7 @@ namespace Box2D.NetStandard.Dynamics.Contacts
 				}
 
 				// Compute a tentative new simplex vertex using support points.
-				SimplexVertex vertex = vertices[simplex.m_count];
+				ref SimplexVertex vertex = ref vertices[simplex.m_count];
 				vertex.indexA = proxyA.GetSupport(Math.MulT(transformA.q, -d));
 				vertex.wA = Math.Mul(transformA, proxyA.GetVertex(vertex.indexA));
 				vertex.indexB = proxyB.GetSupport(Math.MulT(transformB.q, d));

--- a/src/box2dx/Box2D.NetStandard/Dynamics/Fixtures/Fixture.cs
+++ b/src/box2dx/Box2D.NetStandard/Dynamics/Fixtures/Fixture.cs
@@ -44,7 +44,7 @@ namespace Box2D.NetStandard.Dynamics.Fixtures
 	///  Fixtures are created via Body.CreateFixture.
 	///  @warning you cannot reuse fixtures.
 	/// </summary>
-	[DebuggerDisplay("Fixture of {m_body.m_userData}")]
+	[DebuggerDisplay("Fixture of {m_body.UserData}")]
 	public class Fixture
 	{
 		internal Body m_body;


### PR DESCRIPTION
- Sensor bodies didn't detect contacts correctly due to distance calculations not storing data in structs because of missing "ref".
- Fixture DebuggerDisplay string was incorrect.