### PR TITLE
Fix ApplyTorque

### DIFF
--- a/src/box2dx/Box2D.NetStandard/Dynamics/Bodies/Body.cs
+++ b/src/box2dx/Box2D.NetStandard/Dynamics/Bodies/Body.cs
@@ -448,7 +448,7 @@ namespace Box2D.NetStandard.Dynamics.Bodies
 
 			if (HasFlag(BodyFlags.Awake))
 			{
-				m_torque += m_torque;
+				m_torque += torque;
 			}
 		}
 


### PR DESCRIPTION
ApplyTorque doesn't currently work because the `float torque` argument is never used. Looks like it was a typo, where `m_torque` was added to itself.

see reference: https://github.com/erincatto/box2d/blob/c6cc3646d1701ab3c0750ef397d2d68fc6dbcff2/include/box2d/b2_body.h#L795