### PR TITLE
Fix Body.DestroyFixture()

### DIFF
--- a/src/box2dx/Box2D.NetStandard.UnitTests/Dynamics/Bodies/BodyTests.cs
+++ b/src/box2dx/Box2D.NetStandard.UnitTests/Dynamics/Bodies/BodyTests.cs
@@ -1,0 +1,90 @@
+﻿using Box2D.NetStandard.Collision.Shapes;
+using Box2D.NetStandard.Dynamics.Bodies;
+using Box2D.NetStandard.Dynamics.Fixtures;
+using Box2D.NetStandard.Dynamics.World;
+using Xunit;
+
+namespace Box2D.NetStandard.UnitTests.Dynamics.Bodies
+{
+    public class BodyTests
+    {
+        private readonly Body sut;
+
+        public BodyTests()
+        {
+            var world = new World();
+            var bd = new BodyDef();
+
+            sut = world.CreateBody(bd);
+        }
+
+        [Fact]
+        public void CanDestroyTopFixture()
+        {
+            //arrange
+            var fixtureDef = new FixtureDef() { shape = new PolygonShape(1, 1) };
+            var fixture1 = sut.CreateFixture(fixtureDef);
+            var fixture2 = sut.CreateFixture(fixtureDef);
+            var fixture3 = sut.CreateFixture(fixtureDef);
+
+            Assert.Equal(fixture3, sut.GetFixtureList()); //ensure that fixture3 is still the first in the linked list, per current implementation
+
+
+            //act
+            sut.DestroyFixture(fixture3);
+
+
+            //assert
+            Assert.Null(fixture3.Body);
+            Assert.Null(fixture3.Next);
+            Assert.Equal(fixture2, sut.GetFixtureList());
+            Assert.Equal(fixture1, fixture2.Next);
+        }
+
+        [Fact]
+        public void CanDestroyMiddleFixture()
+        {
+            //arrange
+            var fixtureDef = new FixtureDef() { shape = new PolygonShape(1, 1) };
+            var fixture1 = sut.CreateFixture(fixtureDef);
+            var fixture2 = sut.CreateFixture(fixtureDef);
+            var fixture3 = sut.CreateFixture(fixtureDef);
+
+            Assert.Equal(fixture2, sut.GetFixtureList().Next); //ensure that fixture2 is the second in the linked list, per current implementation
+
+
+            //act
+            sut.DestroyFixture(fixture2);
+
+
+            //assert
+            Assert.Null(fixture2.Body);
+            Assert.Null(fixture2.Next);
+            Assert.Equal(fixture3, sut.GetFixtureList());
+            Assert.Equal(fixture1, fixture3.Next);
+        }
+
+        [Fact]
+        public void CanDestroyLastFixture()
+        {
+            //arrange
+            var fixtureDef = new FixtureDef() { shape = new PolygonShape(1, 1) };
+            var fixture1 = sut.CreateFixture(fixtureDef);
+            var fixture2 = sut.CreateFixture(fixtureDef);
+            var fixture3 = sut.CreateFixture(fixtureDef);
+
+            Assert.Equal(fixture1, sut.GetFixtureList().Next.Next); //ensure that fixture1 is the third in the linked list, per current implementation
+
+
+            //act
+            sut.DestroyFixture(fixture1);
+
+
+            //assert
+            Assert.Null(fixture1.Body);
+            Assert.Null(fixture1.Next);
+            Assert.Equal(fixture3, sut.GetFixtureList());
+            Assert.Equal(fixture2, fixture3.Next);
+        }
+    }
+}

--- a/src/box2dx/Box2D.NetStandard/Dynamics/Bodies/Body.cs
+++ b/src/box2dx/Box2D.NetStandard/Dynamics/Bodies/Body.cs
@@ -268,19 +268,28 @@ namespace Box2D.NetStandard.Dynamics.Bodies
 			// Remove the fixture from this body's singly linked list.
 			//Debug.Assert(_fixtureCount > 0);
 			Fixture node = m_fixtureList;
+			Fixture prevNode = null;
+			bool found = false;
 			while (node != null)
 			{
-				if (node.m_next == fixture)
+				if (node == fixture)
 				{
-					node.m_next = fixture.m_next;
+					if (prevNode == null)
+						m_fixtureList = fixture.m_next;
+					else
+						prevNode.m_next = fixture.m_next;
+
+					found = true;
 					break;
 				}
 
+				prevNode = node;
 				node = node.m_next;
 			}
 
 			// You tried to remove a shape that is not attached to this body.
-			//Debug.Assert(found);
+			if (!found)
+				throw new System.ArgumentException("Fixture does not belong to this Body.", nameof(fixture));
 
 			float density = fixture.m_density;
 

--- a/src/box2dx/Box2D.NetStandard/Dynamics/Bodies/Body.cs
+++ b/src/box2dx/Box2D.NetStandard/Dynamics/Bodies/Body.cs
@@ -282,6 +282,8 @@ namespace Box2D.NetStandard.Dynamics.Bodies
 			// You tried to remove a shape that is not attached to this body.
 			//Debug.Assert(found);
 
+			float density = fixture.m_density;
+
 			// Destroy any contacts associated with the fixture.
 			ContactEdge edge = m_contactList;
 			while (edge != null)
@@ -311,8 +313,11 @@ namespace Box2D.NetStandard.Dynamics.Bodies
 
 			--m_fixtureCount;
 
-			// Reset the mass data.
-			ResetMassData();
+			if (density > 0.0f)
+			{
+				// Reset the mass data.
+				ResetMassData();
+			}
 		}
 
 		public void SetTransform(in Vector2 position, float angle)


### PR DESCRIPTION
Fixed 2 of 3 use cases that broke fixtures when using Body.DestroyFixture #38.

I implemented those use cases in 3 new unit tests, for when the Fixture to be destroyed is
- At the start of the linked list (was broken)
- In the middle of the linked list (was broken)
- At the end of the linked list (worked)

While I was in that method, I also implemented an optimization for when to Reset the Mass of the Body based on https://github.com/erincatto/box2d/blob/9dc24a6fd4f32442c4bcf80791de47a0a7d25afb/src/dynamics/b2_body.cpp#L284

