### PR TITLE
ContactEdge: changed fields from protected to public

### DIFF
--- a/src/box2dx/Box2D.NetStandard/Dynamics/Contacts/ContactEdge.cs
+++ b/src/box2dx/Box2D.NetStandard/Dynamics/Contacts/ContactEdge.cs
@@ -41,21 +41,21 @@ namespace Box2D.NetStandard.Dynamics.Contacts
         /// <summary>
         ///  The contact.
         /// </summary>
-        internal Contact contact;
+        public Contact contact;
 
         /// <summary>
         ///  The next contact edge in the body's contact list.
         /// </summary>
-        internal ContactEdge next;
+        public ContactEdge next;
 
         /// <summary>
         ///  Provides quick access to the other body attached.
         /// </summary>
-        internal Body other;
+        public Body other;
 
         /// <summary>
         ///  The previous contact edge in the body's contact list.
         /// </summary>
-        internal ContactEdge prev;
+        public ContactEdge prev;
     }
 }


### PR DESCRIPTION
Fields in ContactEdge were protected, making body.GetContactList() unusable. In original C++ they are implicitly public (see [ContactEdge.h](https://github.com/erincatto/box2d/blob/main/include/box2d/b2_contact.h) Ln.77).