### PR TITLE
Fix Zero-Vector Normalize

### DIFF
--- a/src/box2dx/Box2D.NetStandard/Dynamics/Contacts/ContactSolver.cs
+++ b/src/box2dx/Box2D.NetStandard/Dynamics/Contacts/ContactSolver.cs
@@ -780,10 +780,7 @@ namespace Box2D.NetStandard.Dynamics.Contacts
                         {
                             Vector2 pointA = Common.Math.Mul(xfA, pc.localPoint);
                             Vector2 pointB = Common.Math.Mul(xfB, pc.localPoints[0]);
-                            if (pointA == pointB)
-                                normal = new Vector2(0, 1);
-                            else
-                                normal = Vector2.Normalize(pointB - pointA);
+                            normal = pointA == pointB ? Vector2.UnitY : Vector2.Normalize(pointB - pointA);
                             point = 0.5f * (pointA + pointB);
                             separation = Vector2.Dot(pointB - pointA, normal) - pc.radiusA - pc.radiusB;
                             break;

--- a/src/box2dx/Box2D.NetStandard/Dynamics/Contacts/ContactSolver.cs
+++ b/src/box2dx/Box2D.NetStandard/Dynamics/Contacts/ContactSolver.cs
@@ -780,7 +780,10 @@ namespace Box2D.NetStandard.Dynamics.Contacts
                         {
                             Vector2 pointA = Common.Math.Mul(xfA, pc.localPoint);
                             Vector2 pointB = Common.Math.Mul(xfB, pc.localPoints[0]);
-                            normal = Vector2.Normalize(pointB - pointA);
+                            if (pointA == pointB)
+                                normal = new Vector2(0, 1);
+                            else
+                                normal = Vector2.Normalize(pointB - pointA);
                             point = 0.5f * (pointA + pointB);
                             separation = Vector2.Dot(pointB - pointA, normal) - pc.radiusA - pc.radiusB;
                             break;


### PR DESCRIPTION
Hi, I found out that Vector2.Normalize return (Nan, Nan) with input Vector.Zero at ContactSolver.cs
Which means, if you spawn two circle object at same position, it works wrong.
With two circles, we have to choose which way these two objects move. 
So i decided to use Vector(0, 1) when they have same initial position.

Thanks
