### PR TITLE
add bug fix when sensor collides with a non-sensor

### DIFF
--- a/src/box2dx/Box2D.NetStandard/Dynamics/World.cs
+++ b/src/box2dx/Box2D.NetStandard/Dynamics/World.cs
@@ -910,7 +910,7 @@ namespace Box2DX.Dynamics
 
 				for (Contact c = _contactList; c != null; c = c._next)
 				{
-					if ((int)(c._flags & (Contact.CollisionFlags.Slow | Contact.CollisionFlags.NonSolid)) == 1)
+					if ((int)(c._flags & (Contact.CollisionFlags.Slow | Contact.CollisionFlags.NonSolid)) != 0)
 					{
 						continue;
 					}


### PR DESCRIPTION
A sensor body colliding with a non-sensor body will impact the velocity of the sensor body. This is a bug fix for that.